### PR TITLE
[AN-57] Add dni validation

### DIFF
--- a/src/main/java/integracionapp/psgtrading/repository/UserRepository.java
+++ b/src/main/java/integracionapp/psgtrading/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByExternalIdentifier(String externalIdentifier);
     Optional<User> findByEmailIgnoreCase(String email);
+    Optional<User> findByEmailIgnoreCaseOrDni(String email, Integer dni);
 }

--- a/src/main/java/integracionapp/psgtrading/service/UserService.java
+++ b/src/main/java/integracionapp/psgtrading/service/UserService.java
@@ -26,9 +26,9 @@ public class UserService {
     }
 
     public User saveUser(String email, String name, String lastName, Integer dni, Location location, String password) {
-        Optional<User> opt = userRepository.findByEmailIgnoreCase(email);
+        Optional<User> opt = userRepository.findByEmailIgnoreCaseOrDni(email, dni);
         if (opt.isPresent()) {
-            throw new CustomRuntimeException(ErrorCode.INVALID_STATE, "Email in use");
+            throw new CustomRuntimeException(ErrorCode.INVALID_STATE, "Email Or DNI in use");
         }
         password = passwordEncoder.encode(password);
         email = email.toLowerCase();

--- a/src/test/java/integracionapp/psgtrading/service/UserServiceTest.java
+++ b/src/test/java/integracionapp/psgtrading/service/UserServiceTest.java
@@ -48,8 +48,8 @@ import static org.mockito.Mockito.*;
     }
 
     @Test
-    void create_EmailInUse() {
-        when(userRepository.findByEmailIgnoreCase(any())).thenReturn(Optional.of(new User()));
+    void create_EmailOrDniInUse() {
+        when(userRepository.findByEmailIgnoreCaseOrDni(any(),any())).thenReturn(Optional.of(new User()));
         Assertions.assertThrows(CustomRuntimeException.class
                 , () -> userService.saveUser("any@mail.com", "", ""
                 ,999, null, ""));


### PR DESCRIPTION
Agrego validación de DNI antes de guardar un usuario en la base y evitar el siguiente error:

`could not execute statement; SQL [n/a]; constraint [uk_jq0ta6mef3p0o47ysw6sflcdl]`