### PR TITLE
Permito desactivar el scheduler desde una variable de entorno en aws

### DIFF
--- a/src/main/java/integracionapp/psgtrading/PsgTradingApplication.java
+++ b/src/main/java/integracionapp/psgtrading/PsgTradingApplication.java
@@ -2,10 +2,8 @@ package integracionapp.psgtrading;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class PsgTradingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/integracionapp/psgtrading/service/CoinService.java
+++ b/src/main/java/integracionapp/psgtrading/service/CoinService.java
@@ -5,6 +5,8 @@ import integracionapp.psgtrading.model.TokenPrice;
 import integracionapp.psgtrading.repository.SymbolRepository;
 import integracionapp.psgtrading.repository.TokenPriceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@EnableScheduling
+@ConditionalOnProperty(name = "coinmarket.scheduled", havingValue = "true")
 public class CoinService {
     @Autowired
     private NewStockService newStockService;

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -3,3 +3,5 @@ spring.datasource.username= ${RDS_USERNAME}
 spring.datasource.password= ${RDS_PASSWORD}
 provider.google.client_id=${PROVIDER_GOOGLE_CLIENT_ID}
 provider.google.secret=${PROVIDER_GOOGLE_SECRET}
+coinmarket.apikey=${COIN_API_KEY}
+coinmarket.scheduled=${COINMARKET_SCHEDULED}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,8 +13,9 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 server.error.include-stacktrace=on_param
 
-coinmarket.apikey=502593be-8fd2-46dc-8c75-29a4b9084d33
+coinmarket.apikey=6967288a-6e0b-4def-8e78-8947b02ea426
 coinmarket.host=https://pro-api.coinmarketcap.com/v1/
+coinmarket.scheduled=false
 
 # Security
 jwt.secret=6v9y$B&E)H+MbQeThWmZq4t7w!z%C*F-


### PR DESCRIPTION
 Lo mimo con la api key. Se puede setear desde AWS como variable de entorno

![image](https://github.com/uade-psg-trading/psg-rest-service/assets/88568545/3b1205a9-a42e-4b68-a54e-091eb3da9d80)
